### PR TITLE
PR for MSLQ-61: References

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,8 +74,8 @@ Common
 
 - Start mavros and VRPN for mocap: ```roslaunch mslquad quad_vrpn.launch```
 
-- May need to change ```vrpn_server_ip``` in ```launch/vrpn.launch``` to the ip
-  address of the mocap machine.
+- May need to change ```vrpn_server_ip``` in ```launch/vrpn.launch``` to
+  ```mocap```.
 
 Trajectory Following
 ~~~~~~~~~~~~~~~~~~~~
@@ -88,9 +88,6 @@ Trajectory Following
 - The controller accepts trajectory from topic ```command/trajectory```, which
   is of type *MultiDOFJointTrajectory*. It's important that the trajectory is
   updated at least 10Hz since the controller uses a simple lookahead strategy.
-
-- At the moment, the controller operates at a fixed height (only works for 2D
-  trajectory). 3D trajectory is TODO. 
 
 Tests
 ~~~~~

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,12 +74,14 @@ Common
 
 - Start mavros and VRPN for mocap: ```roslaunch mslquad quad_vrpn.launch```
 
-- May need to change ```vrpn_server_ip``` in ```launch/vrpn.launch``` to the ip address of the mocap machine.
+- May need to change ```vrpn_server_ip``` in ```launch/vrpn.launch``` to the ip
+  address of the mocap machine.
 
 Trajectory Following
 ~~~~~~~~~~~~~~~~~~~~
 
-- A basic trajectory following controller is implemented in **src/px4_base_controller.cpp**.
+- A basic trajectory following controller is implemented in 
+  **src/px4_base_controller.cpp**.
 
     ```roslaunch mslquad default_controller.launch```
 
@@ -87,7 +89,8 @@ Trajectory Following
   is of type *MultiDOFJointTrajectory*. It's important that the trajectory is
   updated at least 10Hz since the controller uses a simple lookahead strategy.
 
-- At the moment, the controller operates at a fixed height (only works for 2D trajectory). 3D trajectory is TODO. 
+- At the moment, the controller operates at a fixed height (only works for 2D
+  trajectory). 3D trajectory is TODO. 
 
 Tests
 ~~~~~

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,9 +57,9 @@ Software Versions
 Dependencies
 ------------
 
-- glog: https://github.com/ethz-asl/glog_catkin
-- ros_vrpn_client: https://github.com/StanfordMSL/ros_vrpn_client
-- Eigen3
+- `glog <https://github.com/ethz-asl/glog_catkin>`_
+- `ros_vrpn_client <https://github.com/StanfordMSL/ros_vrpn_client>`_
+- `Eigen3 <http://eigen.tuxfamily.org/>`_
 
 Compiling
 ---------
@@ -83,7 +83,9 @@ Trajectory Following
 
     ```roslaunch mslquad default_controller.launch```
 
-- The controller accepts trajectory from topic ```command/trajectory```, which is of type *MultiDOFJointTrajectory*. It's important that the trajectory is updated at least 10Hz since the controller uses a simple lookahead strategy.
+- The controller accepts trajectory from topic ```command/trajectory```, which
+  is of type *MultiDOFJointTrajectory*. It's important that the trajectory is
+  updated at least 10Hz since the controller uses a simple lookahead strategy.
 
 - At the moment, the controller operates at a fixed height (only works for 2D trajectory). 3D trajectory is TODO. 
 
@@ -98,7 +100,8 @@ Tests
     
     ```roslaunch mslquad vel_ctrl_test.launch```
 
-- Experimental: test direct motor control (se3 control). This requires <a href="https://github.com/StanfordMSL/Firmware/tree/msl-quads-manip" target="_blank">custom PX4 firmware</a>:
+- Experimental: test direct motor control (se3 control). This requires
+  `custom PX4 firmware <https://github.com/StanfordMSL/Firmware/tree/msl-quads-manip>`_
 
     ```roslaunch mslquad se3controller.launch```
 
@@ -114,53 +117,25 @@ Demo Videos
 Related Papers
 ==============
 
-If you find our work useful in your research, please consider citing:
-
-Hardware & Experiments
-----------------------
-
-- Z. Wang, R. Spica and M. Schwager, “Game Theoretic Motion Planning for
-  Multi-Robot Racing,” In Proc. of the International Symposium on Distributed
-  Autonomous Robotics Systems (DARS 18), October, 2018.
-  `PDF <https://msl.stanford.edu/sites/default/files/wang-etal-dars18-mlt-rbt-racing.pdf>`_
-
-Trajectory Generation
----------------------
-
-- Z. Wang, S. Singh, M. Pavone and M. Schwager, “Cooperative Object Transport in
-  3D with Multiple Quadrotors using No Peer Communication,” In Proc. of the
-  International Conference on Robotics and Automation (ICRA), pp. 1064-1071,
-  2018.
-  `PDF <https://msl.stanford.edu/sites/default/files/wang.singh_.pavone.ea_.icra18.pdf>`_
-
-Differential Flatness
----------------------
-
-- D. Zhou, Z. Wang and M. Schwager, “Agile Coordination and Assistive Collision
-  Avoidance for Quadrotor Swarms Using Virtual Structures,” IEEE Transactions on
-  Robotics, vol. 34, no. 4, pp. 916-923, 2018.
-  `PDF <https://msl.stanford.edu/sites/default/files/zhou-etal-tro18-structure.pdf>`_
-
-- D. Zhou and M. Schwager, “Vector Field Following for Quadrotors using
-  Differential Flatness,” In Proc. of the International Conference on Robotics
-  and Automation (ICRA), pp. 6567-6572. 2014.
-  `PDF <https://msl.stanford.edu/sites/default/files/zhouschwagericra14quadvectorfield.pdf>`_
+Lab research using the MSL Quadrotors can be found in the
+`References section <references.html>`_.
 
 Contributing
 ============
 
-- Report bug or request feature by opening issues on Github
+- Report bugs or request features by opening issues on `our Github`_
 
 - Contribution is very welcome. Please fork the project and submit pull
   requests. New code will be reviewed before merging into the codebase.
 
 - Common functionality should be implemented in
-  ```src/px4_base_controller.cpp```. New controller should derive from the base
+  ```src/px4_base_controller.cpp```. New controllers should derive from the base
   controller, and override the ```controlLoop()``` function.
 
 - If contributing to documentation, this cheatsheet_ can help if you are
   unfamiliar with Markdown or RST.
   
+.. _our github: https://github.com/StanfordMSL/msl_quad/issues
 .. _cheatsheet: https://hyperpolyglot.org/lightweight-markup
 
 Support

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,9 +74,6 @@ Common
 
 - Start mavros and VRPN for mocap: ```roslaunch mslquad quad_vrpn.launch```
 
-- May need to change ```vrpn_server_ip``` in ```launch/vrpn.launch``` to
-  ```mocap```.
-
 Trajectory Following
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -87,23 +84,8 @@ Trajectory Following
 
 - The controller accepts trajectory from topic ```command/trajectory```, which
   is of type *MultiDOFJointTrajectory*. It's important that the trajectory is
-  updated at least 10Hz since the controller uses a simple lookahead strategy.
-
-Tests
-~~~~~
-
-- Test position control: 
-
-    ```roslaunch mslquad pos_ctrl_test.launch```
-
-- Test velocity control: 
-    
-    ```roslaunch mslquad vel_ctrl_test.launch```
-
-- Experimental: test direct motor control (se3 control). This requires
-  `custom PX4 firmware <https://github.com/StanfordMSL/Firmware/tree/msl-quads-manip>`_
-
-    ```roslaunch mslquad se3controller.launch```
+  updated at a frequency of at least 10Hz since the controller uses a simple
+  lookahead strategy.
 
 Demo Videos
 ===========

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -5,25 +5,51 @@ References
 .. meta::
     :description lang=en: Main page for reference related documentation.
 
-Hardware & Experiments
-----------------------
+.. note::
+    If you find our work useful for your research, please consider citing us.
+
+.. code-block:: latex
+
+    @article{
+        spica2020realtime,
+        author={R. {Spica} and E. {Cristofalo} and Z. {Wang} and E. {Montijano} and M. {Schwager}},
+        journal={IEEE Transactions on Robotics}, 
+        title={A Real-Time Game Theoretic Planner for Autonomous Two-Player Drone Racing}, 
+        year={2020}}
+
+Drone Racing Experiments
+------------------------
+
+- **R. Spica, D. Falanga, E. Cristofalo, E. Montijano, D. Scaramuzza, and M.
+  Schwager**, *“A Real-Time Game Theoretic Planner for Autonomous Two-Player
+  Drone Racing”,* in Robotics: Science and Systems (RSS), Pittsburgh, PA, USA,
+  2018. *DOI: 10.15607/RSS.2018.XIV.040*
+  `PDF <https://msl.stanford.edu/sites/g/files/sbiybj8446/f/rss18_spica.pdf>`_
+
+- **R. Spica, E. Cristofalo, Z. Wang, E. Montijano and M. Schwager**, *"A
+  Real-Time Game Theoretic Planner for Autonomous Two-Player Drone Racing,"* in
+  IEEE Transactions on Robotics, *DOI: 10.1109/TRO.2020.2994881.*
+  `PDF <https://msl.stanford.edu/sites/g/files/sbiybj8446/f/spica2020realtime.pdf>`_
 
 - **Z. Wang, R. Spica and M. Schwager**, *“Game Theoretic Motion Planning for
   Multi-Robot Racing,”* In Proc. of the International Symposium on Distributed
-  Autonomous Robotics Systems (DARS 18), October, 2018.
-  `PDF <https://msl.stanford.edu/sites/default/files/wang-etal-dars18-mlt-rbt-racing.pdf>`_
+  Autonomous Robotics Systems (DARS 18), October, 2018. *DOI:
+  10.1007/978-3-030-05816-6_16*
+  `PDF <https://msl.stanford.edu/sites/g/files/sbiybj8446/f/wang-etal-dars18-mlt-rbt-racing_0.pdf>`_
 
-Trajectory Generation
----------------------
+- **E. Cristofalo, E. Montijano, and M. Schwager**, *"Vision-based Control for
+  Fast 3D Reconstruction with an Aerial Robot”,* IEEE Transactions on Control
+  Systems Technology (TCST), pp. 1-14, 2019. *DOI: 10.1109/TCST.2019.2905227*
+  `PDF <https://msl.stanford.edu/sites/g/files/sbiybj8446/f/cristofalo2019vision.pdf>`_
+
+Quadrotor Trajectory Planning and Control
+-----------------------------------------
 
 - **Z. Wang, S. Singh, M. Pavone and M. Schwager**, *“Cooperative Object
   Transport in 3D with Multiple Quadrotors using No Peer Communication,”* In
   Proc. of the International Conference on Robotics and Automation (ICRA), pp.
   1064-1071, 2018. *DOI: 10.1109/ICRA.2018.8460742*
   `PDF <https://msl.stanford.edu/sites/default/files/wang.singh_.pavone.ea_.icra18.pdf>`_
-
-Differential Flatness
----------------------
 
 - **D. Zhou, Z. Wang and M. Schwager**, *“Agile Coordination and Assistive
   Collision Avoidance for Quadrotor Swarms Using Virtual Structures,”* IEEE
@@ -37,14 +63,7 @@ Differential Flatness
   `PDF <https://msl.stanford.edu/sites/default/files/zhouschwagericra14quadvectorfield.pdf>`_
 
 .. TODO:
-    - Does DARS have DOIs??? Couldn't find the first paper's DOI
-    - Do we have other papers that need to be added?
     - Currently get errors for repeating PDF links. Should we make all or part
       of the reference a link to the PDF?
-
-.. note::
-    If you find our work useful for your research, please consider citing us.
-
-.. TODO:
-    Once the updated lab website with filtering options for publications is
-    compete, we might want to consider using that directly.
+    - Once the updated lab website with filtering options for publications is
+      compete, we might want to consider using that directly.

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -5,48 +5,49 @@ References
 .. meta::
     :description lang=en: Main page for reference related documentation.
 
-.. note::
-    If you find our work useful for your research, please consider citing us.
+.. important::
+    If you find our work useful for your research, please citing us.
 
-.. code-block:: latex
+    .. code-block:: bibtex
 
-    @article{
-        spica2020realtime,
-        author={R. {Spica} and E. {Cristofalo} and Z. {Wang} and E. {Montijano} and M. {Schwager}},
-        journal={IEEE Transactions on Robotics}, 
-        title={A Real-Time Game Theoretic Planner for Autonomous Two-Player Drone Racing}, 
-        year={2020}}
+        @article{
+            spica2020realtime,
+            author={R. {Spica} and E. {Cristofalo} and Z. {Wang} and E. {Montijano} and M. {Schwager}},
+            journal={IEEE Transactions on Robotics}, 
+            title={A Real-Time Game Theoretic Planner for Autonomous Two-Player Drone Racing}, 
+            year={2020}}
 
 Drone Racing Experiments
 ------------------------
 
 - **R. Spica, D. Falanga, E. Cristofalo, E. Montijano, D. Scaramuzza, and M.
   Schwager**, *“A Real-Time Game Theoretic Planner for Autonomous Two-Player
-  Drone Racing”,* in Robotics: Science and Systems (RSS), Pittsburgh, PA, USA,
+  Drone Racing,”* in Robotics: Science and Systems (RSS), Pittsburgh, PA, USA,
   2018. *DOI: 10.15607/RSS.2018.XIV.040*
   `PDF <https://msl.stanford.edu/sites/g/files/sbiybj8446/f/rss18_spica.pdf>`_
 
 - **R. Spica, E. Cristofalo, Z. Wang, E. Montijano and M. Schwager**, *"A
   Real-Time Game Theoretic Planner for Autonomous Two-Player Drone Racing,"* in
-  IEEE Transactions on Robotics, *DOI: 10.1109/TRO.2020.2994881.*
+  IEEE Transactions on Robotics. *DOI: 10.1109/TRO.2020.2994881.*
   `PDF <https://msl.stanford.edu/sites/g/files/sbiybj8446/f/spica2020realtime.pdf>`_
 
 - **Z. Wang, R. Spica and M. Schwager**, *“Game Theoretic Motion Planning for
-  Multi-Robot Racing,”* In Proc. of the International Symposium on Distributed
+  Multi-Robot Racing,”* in Proc. of the International Symposium on Distributed
   Autonomous Robotics Systems (DARS 18), October, 2018. *DOI:
   10.1007/978-3-030-05816-6_16*
   `PDF <https://msl.stanford.edu/sites/g/files/sbiybj8446/f/wang-etal-dars18-mlt-rbt-racing_0.pdf>`_
 
 - **E. Cristofalo, E. Montijano, and M. Schwager**, *"Vision-based Control for
-  Fast 3D Reconstruction with an Aerial Robot”,* IEEE Transactions on Control
-  Systems Technology (TCST), pp. 1-14, 2019. *DOI: 10.1109/TCST.2019.2905227*
-  `PDF <https://msl.stanford.edu/sites/g/files/sbiybj8446/f/cristofalo2019vision.pdf>`_
+  Fast 3D Reconstruction with an Aerial Robot”,* in IEEE Transactions on Control
+  Systems Technology, vol. 28, no. 4, pp. 1189-1202, July, 2020. *DOI:
+  10.1109/TCST.2019.2905227*
+  `PDF <https://msl.stanford.edu/sites/g/files/sbiybj8446/f/cristofalo2020vision.pdf>`_
 
 Quadrotor Trajectory Planning and Control
 -----------------------------------------
 
 - **Z. Wang, S. Singh, M. Pavone and M. Schwager**, *“Cooperative Object
-  Transport in 3D with Multiple Quadrotors using No Peer Communication,”* In
+  Transport in 3D with Multiple Quadrotors using No Peer Communication,”* in
   Proc. of the International Conference on Robotics and Automation (ICRA), pp.
   1064-1071, 2018. *DOI: 10.1109/ICRA.2018.8460742*
   `PDF <https://msl.stanford.edu/sites/default/files/wang.singh_.pavone.ea_.icra18.pdf>`_
@@ -58,8 +59,8 @@ Quadrotor Trajectory Planning and Control
   `PDF <https://msl.stanford.edu/sites/default/files/zhou-etal-tro18-structure.pdf>`_
 
 - **D. Zhou and M. Schwager**, *“Vector Field Following for Quadrotors using
-  Differential Flatness,”* In Proc. of the International Conference on Robotics
-  and Automation (ICRA), pp. 6567-6572. 2014. *DOI: 10.1109/ICRA.2014.6907828*
+  Differential Flatness,”* in Proc. of the International Conference on Robotics
+  and Automation (ICRA), pp. 6567-6572, 2014. *DOI: 10.1109/ICRA.2014.6907828*
   `PDF <https://msl.stanford.edu/sites/default/files/zhouschwagericra14quadvectorfield.pdf>`_
 
 .. TODO:

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -37,11 +37,14 @@ Differential Flatness
   `PDF <https://msl.stanford.edu/sites/default/files/zhouschwagericra14quadvectorfield.pdf>`_
 
 .. TODO:
-    Does DARS have DOIs??? Couldn't find the first paper's DOI
+    - Does DARS have DOIs??? Couldn't find the first paper's DOI
+    - Do we have other papers that need to be added?
+    - Currently get errors for repeating PDF links. Should we make all or part
+      of the reference a link to the PDF?
 
 .. note::
     If you find our work useful for your research, please consider citing us.
 
 .. TODO:
-    Once the updated lab website with filtering options for publications, we
-    might want to consider using that directly.
+    Once the updated lab website with filtering options for publications is
+    compete, we might want to consider using that directly.

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -19,7 +19,7 @@ Trajectory Generation
 - **Z. Wang, S. Singh, M. Pavone and M. Schwager**, *“Cooperative Object
   Transport in 3D with Multiple Quadrotors using No Peer Communication,”* In
   Proc. of the International Conference on Robotics and Automation (ICRA), pp.
-  1064-1071, 2018.
+  1064-1071, 2018. *DOI: 10.1109/ICRA.2018.8460742*
   `PDF <https://msl.stanford.edu/sites/default/files/wang.singh_.pavone.ea_.icra18.pdf>`_
 
 Differential Flatness
@@ -27,16 +27,17 @@ Differential Flatness
 
 - **D. Zhou, Z. Wang and M. Schwager**, *“Agile Coordination and Assistive
   Collision Avoidance for Quadrotor Swarms Using Virtual Structures,”* IEEE
-  Transactions on Robotics, vol. 34, no. 4, pp. 916-923, 2018.
+  Transactions on Robotics, vol. 34, no. 4, pp. 916-923, 2018. *DOI:
+  10.1109/TRO.2018.2857477*
   `PDF <https://msl.stanford.edu/sites/default/files/zhou-etal-tro18-structure.pdf>`_
 
 - **D. Zhou and M. Schwager**, *“Vector Field Following for Quadrotors using
   Differential Flatness,”* In Proc. of the International Conference on Robotics
-  and Automation (ICRA), pp. 6567-6572. 2014.
+  and Automation (ICRA), pp. 6567-6572. 2014. *DOI: 10.1109/ICRA.2014.6907828*
   `PDF <https://msl.stanford.edu/sites/default/files/zhouschwagericra14quadvectorfield.pdf>`_
 
 .. TODO:
-    Add DOIs
+    Does DARS have DOIs??? Couldn't find the first paper's DOI
 
 .. note::
     If you find our work useful for your research, please consider citing us.

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -4,3 +4,43 @@ References
 
 .. meta::
     :description lang=en: Main page for reference related documentation.
+
+Hardware & Experiments
+----------------------
+
+- **Z. Wang, R. Spica and M. Schwager**, *“Game Theoretic Motion Planning for
+  Multi-Robot Racing,”* In Proc. of the International Symposium on Distributed
+  Autonomous Robotics Systems (DARS 18), October, 2018.
+  `PDF <https://msl.stanford.edu/sites/default/files/wang-etal-dars18-mlt-rbt-racing.pdf>`_
+
+Trajectory Generation
+---------------------
+
+- **Z. Wang, S. Singh, M. Pavone and M. Schwager**, *“Cooperative Object
+  Transport in 3D with Multiple Quadrotors using No Peer Communication,”* In
+  Proc. of the International Conference on Robotics and Automation (ICRA), pp.
+  1064-1071, 2018.
+  `PDF <https://msl.stanford.edu/sites/default/files/wang.singh_.pavone.ea_.icra18.pdf>`_
+
+Differential Flatness
+---------------------
+
+- **D. Zhou, Z. Wang and M. Schwager**, *“Agile Coordination and Assistive
+  Collision Avoidance for Quadrotor Swarms Using Virtual Structures,”* IEEE
+  Transactions on Robotics, vol. 34, no. 4, pp. 916-923, 2018.
+  `PDF <https://msl.stanford.edu/sites/default/files/zhou-etal-tro18-structure.pdf>`_
+
+- **D. Zhou and M. Schwager**, *“Vector Field Following for Quadrotors using
+  Differential Flatness,”* In Proc. of the International Conference on Robotics
+  and Automation (ICRA), pp. 6567-6572. 2014.
+  `PDF <https://msl.stanford.edu/sites/default/files/zhouschwagericra14quadvectorfield.pdf>`_
+
+.. TODO:
+    Add DOIs
+
+.. note::
+    If you find our work useful for your research, please consider citing us.
+
+.. TODO:
+    Once the updated lab website with filtering options for publications, we
+    might want to consider using that directly.

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -6,7 +6,7 @@ References
     :description lang=en: Main page for reference related documentation.
 
 .. important::
-    If you find our work useful for your research, please citing us.
+    If you find our work useful for your research, please cite our publications.
 
     .. code-block:: bibtex
 
@@ -28,7 +28,7 @@ Drone Racing Experiments
 
 - **R. Spica, E. Cristofalo, Z. Wang, E. Montijano and M. Schwager**, *"A
   Real-Time Game Theoretic Planner for Autonomous Two-Player Drone Racing,"* in
-  IEEE Transactions on Robotics. *DOI: 10.1109/TRO.2020.2994881.*
+  IEEE Transactions on Robotics. 2020. *DOI: 10.1109/TRO.2020.2994881.*
   `PDF <https://msl.stanford.edu/sites/g/files/sbiybj8446/f/spica2020realtime.pdf>`_
 
 - **Z. Wang, R. Spica and M. Schwager**, *“Game Theoretic Motion Planning for


### PR DESCRIPTION
Updates the References section and related content for the documentation.

Right now I have the content from the existing documentation in the Reference section. Do we have more papers that need to be added? I'd guess this is a bit outdated at this point. Make sure to check the TODOs as there are a couple of things to address before the PR should be approved.

- Updates the main page.
  - Moves papers content over to References page.
  - Adds some links throughout the page.
  - Fixes some formatting.
- Adds content to the References page.