### PR TITLE
PR for MSLQ-62: External Resources

### DIFF
--- a/docs/source/external_resources.rst
+++ b/docs/source/external_resources.rst
@@ -24,6 +24,8 @@ Below is a list of useful resources while working with the quadrotor repository.
 * `UAV Game Theoretic Planner <https://github.com/StanfordMSL/uav_game>`_
 
 * `Odroid <https://wiki.odroid.com/>`_
-.. TODO:: Above should be removed once no longer used
-.. TODO:: Link to Odroid image we will be using?
-.. TODO:: Any other resources for v1.0?
+
+..
+  TODO:: Odroid line should be removed once no longer used
+  TODO:: Link to Odroid image we will be using?
+  TODO:: Any other resources for v1.0?

--- a/docs/source/external_resources.rst
+++ b/docs/source/external_resources.rst
@@ -5,4 +5,25 @@ External Resources
 .. meta::
     :description lang=en: Main page for external resource related documentation.
 
-.. TODO: Stanford Flightroom, QGround control docs, PX4 docs, MSL github, odroid (cloned image), 
+Below is a list of useful resources while working with the quadrotor repository.
+
+* `Stanford Flightroom <https://stanfordflightroom.github.io/>`_
+
+* `QGroundControl <https://docs.qgroundcontrol.com/en/>`_
+
+* `PX4 <https://docs.px4.io/master/en/index.html>`_
+
+* `MSL GitHub <https://github.com/StanfordMSL>`_
+
+* `MSL Raptor <https://github.com/StanfordMSL/MSL-RAPTOR>`_
+
+* `Quad Manip <https://github.com/StanfordMSL/QuadsManip>`_
+
+* `Quadrotor Sim <https://github.com/StanfordMSL/quadrotor_sim>`_
+
+* `UAV Game Theoretic Planner <https://github.com/StanfordMSL/uav_game>`_
+
+* `Odroid <https://wiki.odroid.com/>`_
+.. TODO:: Above should be removed once no longer used
+.. TODO:: Link to Odroid image we will be using?
+.. TODO:: Any other resources for v1.0?

--- a/docs/source/external_resources.rst
+++ b/docs/source/external_resources.rst
@@ -5,7 +5,7 @@ External Resources
 .. meta::
     :description lang=en: Main page for external resource related documentation.
 
-Below is a list of useful resources while working with the quadrotor repository.
+Below is a collection of useful resources while working with the quadrotors.
 
 * `Stanford Flightroom <https://stanfordflightroom.github.io/>`_
 
@@ -27,5 +27,5 @@ Below is a list of useful resources while working with the quadrotor repository.
 
 ..
   TODO:: Odroid line should be removed once no longer used
-  TODO:: Link to Odroid image we will be using?
-  TODO:: Any other resources for v1.0?
+  TODO:: Link to Odroid image we will be using? Doesn't exist ATM
+  TODO:: Any other resources for v1.0???


### PR DESCRIPTION
Updates the External Resources page with links to important websites.

Right now this is pretty light. Do we want more than just a couple of related MSL repos and the main hardware vendor sites?